### PR TITLE
Add a WSGI server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,5 +108,6 @@ venv.bak/
 # do not upload settings
 settings.json
 hosts.json
+subdomains.json
 
 .idea/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,29 @@ Options:
   --help             Show this message and exit.
 
 ```
+
+## Server usage
+You can also use this repository as a DynDNS server (based on Flask) on a trusted host.
+With that, you can call an URL with predefined parameters and the server will update the DNS settings.
+
+The service accepts URLs in the form:
+```
+http://myhost.com/<key>?ipv4=<ipv4>&ipv6=<ipv6>
+```
+
+### Deployment
+
+1. Provide a `settings.json` as described in the next section.
+   The server recognizes the environment variable `DYNDNS_SETTINGS` as file path (default is `settings.json`).
+2. Provide a `subdomains.json` as described further down.
+3. Connect the Flask app to your webserver. For example, this is possible with [gunicorn](https://gunicorn.org/) and systemd.
+   For that, adjust the paths in `dnydns-server.service`, copy it in `/etc/systemd/system/`, and start it.
+   Adjust also your webserver. For example, with nginx, add these lines:
+```
+location /dyndns/ {
+	proxy_pass http://localhost:40404/;
+}
+```
  
 ## API settings
  This `settings.json` file configures the api credentials.
@@ -59,6 +82,17 @@ Options:
 If you would like to use your [FRITZ!Box](https://en.wikipedia.org/wiki/Fritz!Box) for getting your external ip, you need to add its ip address in this `json` file:
  ```
   "FRITZBOX_IP":    "192.168.178.1"
+```
+
+If you will run the service as a server, you need to provide a few additional entries:
+
+ * The file path to the `subdomains.json` file (relative to `settings.json`)
+```
+  "SUBDOMAINS": "subdomains.json"
+```
+ * A log level (optional)
+```
+  "LOG_LEVEL": "DEBUG"
 ```
 
 ## Host records
@@ -88,6 +122,28 @@ If no `destination` is specified, the found external ip will be used.
     }
   ]
 }
+```
+
+## Subdomains
+When run in server mode, an additional file specifies a mapping between the key and the hostname:
+```json
+{
+  "domainname": "example.com",
+  "hosts":  [
+    {
+      "hostname": "alice",
+      "key":      "3is83sen"
+    },
+    {
+      "hostname": "bob",
+      "key":      "s8dfwske"
+    }
+  ]
+}
+```
+With that file the domain `alice.example.com` can be updated by calling the URL:
+```
+http://myhost.com/3is83sen?ipv4=10.10.10.10
 ```
 
 ## API usage examples

--- a/dyndns-server.service
+++ b/dyndns-server.service
@@ -1,0 +1,18 @@
+[Unit]
+Description = DynDNS server gunicorn
+After = network.target
+
+[Service]
+PIDFile=/run/dyndns/pid
+RuntimeDirectory=dyndns
+PermissionsStartOnly = true
+User = dyndns
+Group = dyndns
+WorkingDirectory = /opt/netcup-dyndns/
+ExecStart = gunicorn 'server:app' --pid /run/dyndns/pid --bind '127.0.0.1:40404' --workers 1 --access-logfile - --log-file -
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s TERM $MAINPID
+PrivateTmp = true
+
+[Install]
+WantedBy = multi-user.target

--- a/dyndns.py
+++ b/dyndns.py
@@ -59,21 +59,8 @@ def import_zone(filename: str) -> str:
 
 def modify_recordset(old_set: DNSRecordSet, new_set: DNSRecordSet) -> (DNSRecordSet, bool):
     changed = False
-    for new_record in new_set.dnsrecords:
-        # record with this hostname exists
-        if new_record.hostname in old_set:
-            # get record and update it
-            old_record = old_set.get_by_hostname(new_record.hostname)
-            # check if update needed
-            if old_record.needs_update(record=new_record):
-                changed = True
-                old_record.destination = new_record.destination
-                old_record.type = new_record.type
-
-        # does not exist, create it
-        else:
-            changed = True
-            old_set.add(new_record)
+    for new_record in new_set:
+        changed |= old_set.add(new_record)
 
     # finally return the modified set
     return old_set, changed

--- a/dyndns.py
+++ b/dyndns.py
@@ -14,11 +14,11 @@ This script will not check the sanity of your entries!
 import json
 import logging
 from ipaddress import IPv4Address
+from typing import Dict, Any
 
 import click
 
 from nc_api import NcAPI, DNSRecord, DNSRecordSet
-from nc_api.utils.external_ip import ExternalIpify, ExternalFritzbox
 
 
 def import_hosts(filename: str, ip: IPv4Address) -> DNSRecordSet:
@@ -66,6 +66,55 @@ def modify_recordset(old_set: DNSRecordSet, new_set: DNSRecordSet) -> (DNSRecord
     return old_set, changed
 
 
+def update_dyndns(settings: Dict[str, Any], domainname: str, new_records: DNSRecordSet, update: bool = True, ttl:int = None):
+    """Set the domain according to the given parameters.
+
+    :param settings: API settings (see settings.json.sample)
+    :param domainname: the domain which subdomains should be changed
+    :param new_records: a new set of records which should be submitted
+    :param update: do the actual update (otherwise it is a dry run)
+    :param ttl: if specified, also modify the TTL
+    """
+    # api related part
+    with NcAPI(api_url=settings["API_URL"],
+               api_key=settings["API_KEY"],
+               api_password=settings["API_PASSWORD"],
+               customer_id=settings["CUSTOMER_ID"]) as api:
+        # read current dns zone
+        zone = api.infoDnsZone(domainname=domainname)
+        logging.debug("Zone Table: %s", zone.table())
+
+        # read current host records
+        old_set = api.infoDnsRecords(domainname=domainname)
+        logging.debug("Old Records: %s", old_set.table())
+
+        # modify set
+        updated_set, changed = modify_recordset(old_set=old_set,
+                                                new_set=new_records)
+        logging.info("Updated set: %s", updated_set.table())
+
+        if ttl is not None:
+            logging.info("Updating ttl ...")
+            if zone.ttl == ttl:
+                logging.info("ttl has not changed, leaving it alone!")
+            else:
+                zone.ttl = ttl
+                api.updateDnsZone(zone=zone)
+
+                # read zone again
+                logging.debug("\n%s", api.infoDnsZone(domainname=domainname).table())
+
+        if update:
+            logging.info("updating records ...")
+            if changed:
+                api.updateDnsRecords(zone=zone, recordset=updated_set)
+
+                # read current host records
+                logging.debug("\n%s", api.infoDnsRecords(domainname=domainname).table())
+            else:
+                logging.info("records did not change, leaving it alone!")
+
+
 @click.command()
 @click.argument("conf", type=click.Path(exists=True))
 @click.argument("hosts", type=click.Path(exists=True))
@@ -84,6 +133,9 @@ def dyndns(conf, hosts, update: bool=False, ttl: int=None, verbose: bool=False):
     Please review your config in hosts.json, this script will NOT check the sanity of your dns entries.
     !!!
     """
+    # function level import to avoid dependencies when used in server mode
+    from nc_api.utils.external_ip import ExternalIpify, ExternalFritzbox
+
     if verbose:
         logging.basicConfig(level=logging.DEBUG)
 
@@ -117,44 +169,8 @@ def dyndns(conf, hosts, update: bool=False, ttl: int=None, verbose: bool=False):
     # import hosts from file
     new_set = import_hosts(filename=hosts, ip=ip)
 
-    # api related part
-    with NcAPI(api_url=settings["API_URL"],
-               api_key=settings["API_KEY"],
-               api_password=settings["API_PASSWORD"],
-               customer_id=settings["CUSTOMER_ID"]) as api:
-        # read current dns zone
-        zone = api.infoDnsZone(domainname=domainname)
-        print(zone.table())
-
-        # read current host records
-        old_set = api.infoDnsRecords(domainname=domainname)
-        print(old_set.table())
-
-        # modify set
-        updated_set, changed = modify_recordset(old_set=old_set, new_set=new_set)
-        print("\nupdated set:")
-        print(updated_set.table())
-
-        if ttl is not None:
-            print("updating ttl ...")
-            if zone.ttl == ttl:
-                print("ttl has not changed, leaving it alone!")
-            else:
-                zone.ttl = ttl
-                api.updateDnsZone(zone=zone)
-
-                # read zone again
-                print(api.infoDnsZone(domainname=domainname).table())
-
-        if update:
-            print("\n updating records ...")
-            if changed:
-                api.updateDnsRecords(zone=zone, recordset=updated_set)
-
-                # read current host records
-                print(api.infoDnsRecords(domainname=domainname).table())
-            else:
-                print("records did not change, leaving it alone!")
+    # do the actual change
+    update_dyndns(settings, domainname, new_set, update=update, ttl=ttl)
 
 
 if __name__ == "__main__":

--- a/nc_api/exceptions.py
+++ b/nc_api/exceptions.py
@@ -3,9 +3,5 @@ Custom exceptions.
 """
 
 
-class RecordUnknown(Exception):
-    pass
-
-
 class APIException(Exception):
     pass

--- a/server.py
+++ b/server.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+import logging
+import os
+import json
+
+from flask import Flask, request, Response
+from pathlib import PurePath
+
+from dyndns import update_dyndns
+from nc_api import DNSRecord, DNSRecordSet
+
+app = Flask(__name__)
+
+settings_file = os.environ.get("DYNDNS_SETTINGS", "settings.json")
+settings = {}
+with open(settings_file) as f:
+    settings = json.load(f)
+
+logging.basicConfig(level=getattr(logging, settings.get("LOG_LEVEL", "INFO")))
+
+
+@app.route("/<key>")
+def dyndns_serve(key: str) -> Response:
+    # load subdomains
+    with open(PurePath(settings_file).parent / settings["SUBDOMAINS"]) as f:
+        subs = json.load(f)
+    domainname = subs["domainname"]
+    subs = {x["key"]: x["hostname"] for x in subs["hosts"]}
+
+    if key not in subs:
+        return Response(status=403)
+    subdomain = subs[key]
+
+    args = request.args
+
+    if not {"ipv4", "ipv6"} & set(args.keys()):
+        return Response(response="Provide an ipv4 or ipv6 or both.", status=400)
+
+    logging.debug(
+        "Set the subdomain %s to the IPv4: %s and IPv6: %s",
+        subdomain,
+        args.get("ipv4", "-"),
+        args.get("ipv6", "-"),
+    )
+
+    records = DNSRecordSet(dnsrecords=[])
+    if "ipv4" in args:
+        records.add(DNSRecord(hostname=subdomain, type="A", destination=args["ipv4"]))
+    if "ipv6" in args:
+        records.add(
+            DNSRecord(hostname=subdomain, type="AAAA", destination=args["ipv6"])
+        )
+    logging.debug(records)
+    update_dyndns(settings, domainname, records, update=True)
+
+    return Response(status=200)
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=os.environ.get("DYNDNS_PORT", 8081), debug=True)

--- a/subdomains.json.sample
+++ b/subdomains.json.sample
@@ -1,0 +1,13 @@
+{
+  "domainname": "example.com",
+  "hosts":  [
+    {
+      "hostname": "alice",
+      "key":      "3is83sen"
+    },
+    {
+      "hostname": "bob",
+      "key":      "s8dfwske"
+    }
+  ]
+}


### PR DESCRIPTION
This adds the possibility to deploy the project on a trusted server as a WSGI server on a public URL.
For example, a Fritz!Box can then directly call this URL.

I also added functionality for IPv6, if your DynDNS host has DualStack or only a IPv6 address.

I have not tested the standard functionality anymore. It should work like before but maybe I have a bug somewhere.